### PR TITLE
Changing Hero Feature background alpha to darker shade to improve visibility and reduce eye strain

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -319,13 +319,6 @@ nav a:hover {
   position: absolute;
   bottom: 30px;
   left: 30px;
-  background: rgba(255, 255, 255, 255, 0.1);
-}
-
-.hero-feature {
-  position: absolute;
-  bottom: 30px;
-  left: 30px;
   background: rgba(255, 255, 255, 0.08);
   padding: 15px 25px;
   border-radius: 12px;

--- a/styles/main.css
+++ b/styles/main.css
@@ -319,7 +319,7 @@ nav a:hover {
   position: absolute;
   bottom: 30px;
   left: 30px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(68, 68, 68, 0.3);
   padding: 15px 25px;
   border-radius: 12px;
   backdrop-filter: blur(6px);
@@ -331,7 +331,7 @@ nav a:hover {
 }
 
 .hero-feature:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(68, 68, 68, 0.5)
 }
 
 .hero-feature:focus {


### PR DESCRIPTION
Check the bottom left of images to see slight difference. Before version goal circle was completely missed by me when first visiting website. This pull request makes it look clearer:

Before:
![image](https://github.com/user-attachments/assets/52315621-28ff-4eb2-9f97-3a7766c97621)

After:
![image](https://github.com/user-attachments/assets/b8b85d6e-43ab-4958-be08-e1e23c46157f)
