### PR TITLE
Replace native select with custom language dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,12 +229,11 @@ if (window.scrollY > 10) {
       <li><a href="#who-we-are" class="lang" data-key="nav_who">Who We Are</a></li>
       <li>
         <div class="language-switcher">
-          <label for="language-select" class="sr-only">Select Language</label>
-          <select id="language-select" class="language-select" aria-label="Select language">
-            <option value="en">ENG</option>
-            <option value="it">ITA</option>
-            <option value="de">DEU</option>
-          </select>
+          <button class="language-toggle" type="button" aria-haspopup="listbox" aria-expanded="false" aria-controls="language-list-header" aria-label="Language: English">
+            <i class="fas fa-globe" aria-hidden="true"></i>
+            <span class="language-current">ENG</span>
+          </button>
+          <ul class="language-dropdown" id="language-list-header" role="listbox" aria-label="Select language"></ul>
         </div>
       </li>
     </ul>
@@ -635,12 +634,11 @@ if (window.scrollY > 10) {
       </div>
       <div class="footer-column">
         <div class="language-switcher">
-          <label for="language-select-footer" class="sr-only">Select Language</label>
-          <select id="language-select-footer" class="language-select" aria-label="Select language">
-            <option value="en">ENG</option>
-            <option value="it">ITA</option>
-            <option value="de">DEU</option>
-          </select>
+          <button class="language-toggle" type="button" aria-haspopup="listbox" aria-expanded="false" aria-controls="language-list-footer" aria-label="Language: English">
+            <i class="fas fa-globe" aria-hidden="true"></i>
+            <span class="language-current">ENG</span>
+          </button>
+          <ul class="language-dropdown" id="language-list-footer" role="listbox" aria-label="Select language"></ul>
         </div>
         <div class="direct-donate">
           <a href="https://www.gofundme.com/f/associazione-gruppo-nairobi/donate" target="_blank" rel="noopener noreferrer" class="footer-donate-link">

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -45,6 +45,13 @@ window.SITE_CONFIG = {
     cacheTimeout: 300000, // 5 minutes
   },
 
+  // Language Configuration
+  languages: [
+    { code: "en", label: "English", shortLabel: "ENG" },
+    { code: "it", label: "Italiano", shortLabel: "ITA" },
+    { code: "de", label: "Deutsch", shortLabel: "DEU" },
+  ],
+
   // Feature Flags
   features: {
     twitchIntegration: true,

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -118,7 +118,12 @@ class LanguageManager {
   constructor() {
     this.currentLanguage = "en"
     this.translations = window.translations || {}
-    this.selectors = document.querySelectorAll(".language-select")
+    this.languages = (window.SITE_CONFIG && window.SITE_CONFIG.languages) || [
+      { code: "en", label: "English", shortLabel: "ENG" },
+      { code: "it", label: "Italiano", shortLabel: "ITA" },
+      { code: "de", label: "Deutsch", shortLabel: "DEU" },
+    ]
+    this.switchers = document.querySelectorAll(".language-switcher")
     this.storageKey = "selectedLanguage"
 
     this.init()
@@ -128,20 +133,146 @@ class LanguageManager {
     // Load saved language or detect from browser
     const savedLanguage = localStorage.getItem(this.storageKey)
     const browserLanguage = navigator.language.slice(0, 2)
+    const validCodes = this.languages.map((l) => l.code)
 
-    if (savedLanguage && this.translations[savedLanguage]) {
+    if (savedLanguage && validCodes.includes(savedLanguage)) {
       this.currentLanguage = savedLanguage
-    } else if (this.translations[browserLanguage]) {
+    } else if (validCodes.includes(browserLanguage)) {
       this.currentLanguage = browserLanguage
     }
 
-    // Set up event listeners
-    this.selectors.forEach((selector) => {
-      selector.value = this.currentLanguage
-      selector.addEventListener("change", (e) => this.changeLanguage(e.target.value))
+    // Set document language
+    document.documentElement.lang = this.currentLanguage
+
+    // Build dropdown options and bind events for each switcher
+    this.switchers.forEach((switcher) => this.setupSwitcher(switcher))
+
+    this.updateAllSwitchers()
+    this.applyTranslations()
+  }
+
+  setupSwitcher(switcher) {
+    const dropdown = switcher.querySelector(".language-dropdown")
+    const toggle = switcher.querySelector(".language-toggle")
+    const listId = dropdown.id
+
+    // Build options from config
+    dropdown.innerHTML = ""
+    this.languages.forEach((lang) => {
+      const li = document.createElement("li")
+      const optionId = `${listId}-${lang.code}`
+      li.setAttribute("role", "option")
+      li.setAttribute("id", optionId)
+      li.setAttribute("data-lang", lang.code)
+      li.setAttribute("tabindex", "-1")
+      li.setAttribute("aria-selected", lang.code === this.currentLanguage ? "true" : "false")
+      li.textContent = lang.label
+      if (lang.code === this.currentLanguage) {
+        li.classList.add("active")
+        toggle.setAttribute("aria-activedescendant", optionId)
+      }
+      dropdown.appendChild(li)
     })
 
-    this.applyTranslations()
+    // Toggle open/close
+    toggle.addEventListener("click", (e) => {
+      e.stopPropagation()
+      const isOpen = toggle.getAttribute("aria-expanded") === "true"
+      this.closeAllDropdowns()
+      if (!isOpen) this.openDropdown(switcher)
+    })
+
+    // Select language on option click
+    dropdown.addEventListener("click", (e) => {
+      const option = e.target.closest("[data-lang]")
+      if (option) {
+        this.changeLanguage(option.getAttribute("data-lang"))
+        this.closeAllDropdowns()
+        toggle.focus()
+      }
+    })
+
+    // Keyboard navigation
+    toggle.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        this.openDropdown(switcher)
+        // Focus currently active option, or first
+        const active = dropdown.querySelector("[role=option].active") || dropdown.querySelector("[role=option]")
+        if (active) active.focus()
+      }
+    })
+
+    dropdown.addEventListener("keydown", (e) => {
+      const options = [...dropdown.querySelectorAll("[role=option]")]
+      const current = document.activeElement
+      const idx = options.indexOf(current)
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        const next = options[idx + 1] || options[0]
+        next.focus()
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        const prev = options[idx - 1] || options[options.length - 1]
+        prev.focus()
+      } else if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        if (current.hasAttribute("data-lang")) {
+          this.changeLanguage(current.getAttribute("data-lang"))
+          this.closeAllDropdowns()
+          toggle.focus()
+        }
+      } else if (e.key === "Escape") {
+        this.closeAllDropdowns()
+        toggle.focus()
+      } else if (e.key === "Tab") {
+        this.closeAllDropdowns()
+      } else if (e.key === "Home") {
+        e.preventDefault()
+        options[0]?.focus()
+      } else if (e.key === "End") {
+        e.preventDefault()
+        options[options.length - 1]?.focus()
+      }
+    })
+  }
+
+  openDropdown(switcher) {
+    const toggle = switcher.querySelector(".language-toggle")
+    toggle.setAttribute("aria-expanded", "true")
+  }
+
+  closeAllDropdowns() {
+    this.switchers.forEach((s) => {
+      const toggle = s.querySelector(".language-toggle")
+      toggle.setAttribute("aria-expanded", "false")
+    })
+  }
+
+  updateAllSwitchers() {
+    const lang = this.languages.find((l) => l.code === this.currentLanguage)
+    if (!lang) return
+
+    this.switchers.forEach((switcher) => {
+      const toggle = switcher.querySelector(".language-toggle")
+      const current = switcher.querySelector(".language-current")
+      if (current) current.textContent = lang.shortLabel
+
+      // Update button aria-label with current language name
+      toggle.setAttribute("aria-label", `Language: ${lang.label}`)
+
+      // Update active state and aria-selected on options
+      const options = switcher.querySelectorAll("[role=option]")
+      options.forEach((opt) => {
+        const isActive = opt.getAttribute("data-lang") === this.currentLanguage
+        opt.classList.toggle("active", isActive)
+        opt.setAttribute("aria-selected", isActive ? "true" : "false")
+        if (isActive) {
+          toggle.setAttribute("aria-activedescendant", opt.id)
+        }
+      })
+    })
   }
 
   changeLanguage(language) {
@@ -152,13 +283,16 @@ class LanguageManager {
 
     this.currentLanguage = language
     localStorage.setItem(this.storageKey, language)
+    document.documentElement.lang = language
 
-    // Update all selectors
-    this.selectors.forEach((selector) => {
-      selector.value = language
-    })
-
+    this.updateAllSwitchers()
     this.applyTranslations()
+
+    // Announce language change to screen readers
+    const lang = this.languages.find((l) => l.code === language)
+    if (lang && window.announceToScreenReader) {
+      window.announceToScreenReader(`Language changed to ${lang.label}`)
+    }
 
     // Dispatch event for other components
     document.dispatchEvent(
@@ -166,7 +300,6 @@ class LanguageManager {
         detail: { language },
       }),
     )
-
   }
 
   applyTranslations() {
@@ -190,7 +323,9 @@ class LanguageManager {
 
   getTranslation(key) {
     const languageData = this.translations[this.currentLanguage]
-    return languageData ? languageData[key] : null
+    if (languageData && languageData[key]) return languageData[key]
+    const fallback = this.translations["en"]
+    return fallback ? fallback[key] : null
   }
 
   getCurrentLanguage() {
@@ -468,6 +603,13 @@ document.addEventListener("DOMContentLoaded", () => {
         window.languageManager.changeLanguage(language)
       }
     }
+
+    // Close language dropdowns on outside click
+    document.addEventListener("click", (e) => {
+      if (!e.target.closest(".language-switcher")) {
+        window.languageManager.closeAllDropdowns()
+      }
+    })
 
   } catch (error) {
     console.error("❌ Error during core initialization:", error)

--- a/styles/layout/header.css
+++ b/styles/layout/header.css
@@ -98,25 +98,90 @@ nav a:hover::after {
 
 /* Language Switcher */
 .language-switcher {
-  display: flex;
+  position: relative;
+  display: inline-flex;
+}
+
+.language-toggle {
+  display: inline-flex;
   align-items: center;
-}
-
-.language-switcher select {
+  gap: var(--space-sm);
   padding: var(--space-sm);
-  margin: 0;
-  border: 2px solid var(--border-light);
-  border-radius: var(--radius-md);
-  background-color: var(--bg-secondary);
+  border: none;
+  border-radius: var(--radius-full);
+  background: none;
+  appearance: none;
+  -webkit-appearance: none;
   font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--text-primary);
   cursor: pointer;
-  transition: none !important;
+  transition: color var(--transition-fast);
+  line-height: 1;
+  outline: none;
 }
 
-.language-select:focus {
+.language-toggle .fa-globe {
+  font-size: var(--text-base);
+}
+
+.language-toggle:hover {
+  color: var(--brand-accent);
+}
+
+.language-toggle:focus-visible {
   outline: 2px solid var(--brand-accent);
   outline-offset: 2px;
-  transition: none !important;
+}
+
+.language-dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + var(--space-xs));
+  right: 0;
+  min-width: 150px;
+  background: var(--bg-secondary);
+  border: 1.5px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-xs) 0;
+  z-index: 1002;
+  list-style: none;
+  margin: 0;
+}
+
+.language-toggle[aria-expanded="true"] + .language-dropdown {
+  display: block;
+}
+
+.language-dropdown [role="option"] {
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  white-space: nowrap;
+}
+
+.language-dropdown [role="option"]:hover,
+.language-dropdown [role="option"]:focus {
+  background: var(--neutral-100);
+  outline: none;
+}
+
+.language-dropdown [role="option"].active {
+  color: var(--brand-accent);
+  font-weight: 700;
+}
+
+.language-dropdown [role="option"].active::before {
+  content: "\f00c";
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  font-size: 0.65rem;
+  margin-right: var(--space-sm);
 }
 
 /* Mobile Menu */
@@ -189,6 +254,30 @@ nav a:hover::after {
 
   .logo img {
     height: 40px; /* Keep logo size consistent */
+  }
+
+  .language-switcher {
+    justify-content: center;
+  }
+
+  .language-toggle {
+    font-size: var(--text-lg);
+    gap: var(--space-sm);
+  }
+
+  .language-toggle .fa-globe {
+    font-size: var(--text-xl);
+  }
+
+  .language-dropdown {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+
+  .language-dropdown [role="option"] {
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--text-base);
   }
 }
 

--- a/styles/sections/footer.css
+++ b/styles/sections/footer.css
@@ -83,6 +83,12 @@ footer .logo {
   margin-bottom: var(--space-xs);
 }
 
+/* Footer language dropdown opens upward */
+footer .language-dropdown {
+  top: auto;
+  bottom: calc(100% + var(--space-xs));
+}
+
 .direct-donate {
   margin-top: var(--space-md);
 }


### PR DESCRIPTION
- Config-driven language list in SITE_CONFIG for easy additions
- Custom dropdown with globe icon toggle, built from config at runtime
- Full keyboard navigation (arrows, Enter, Space, Escape, Home, End)
- Proper ARIA: haspopup, expanded, controls, activedescendant, aria-selected
- Screen reader announcement on language change, document lang attribute sync
- English fallback for missing translation keys
- Footer dropdown opens upward
- Mobile-friendly tap targets

<img width="1224" height="85" alt="image" src="https://github.com/user-attachments/assets/60053e74-6dec-4c24-9e0a-1ec5cd61cede" />

<img width="263" height="264" alt="image" src="https://github.com/user-attachments/assets/94c9ed26-48bd-4ec9-b1ed-d5c8695ecb0b" />

Closes #41 